### PR TITLE
PMM-2134: rds_exporter exports memory in Kb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,4 +61,4 @@
 [submodule "rds_exporter"]
 	path = sources/rds_exporter/src/github.com/percona/rds_exporter
 	url = https://github.com/percona/rds_exporter
-	branch = master
+	branch = PMM-2134_kilobytes_to_bytes


### PR DESCRIPTION
... with node_exporter labels which are in bytes.