### PR TITLE
PMM-4796 Use stderr for all output.

### DIFF
--- a/build/pmm-client-docker/entrypoint.py
+++ b/build/pmm-client-docker/entrypoint.py
@@ -28,18 +28,17 @@ def main():
     """
 
     if len(sys.argv) > 1:
-        print(__doc__)
+        print(__doc__, file=sys.stderr)
         os.system('pmm-agent setup --help')
         sys.exit(1)
 
     if PMM_AGENT_SETUP:
-        print('Starting pmm-agent setup ...')
+        print('Starting pmm-agent setup ...', file=sys.stderr)
         status = os.system('pmm-agent setup')
         if status != os.EX_OK:
             sys.exit(status)
 
-    print('Starting pmm-agent ...')
-    sys.stdout.flush()
+    print('Starting pmm-agent ...', file=sys.stderr)
     sys.stderr.flush()
 
     # use execlp to replace the current process (this entrypoint)


### PR DESCRIPTION
During the demo, I noticed that `pmm-agent setup --help` text
appeared on screen before entrypoint's help. That makes
"The following help text" wrong.

This PR should fix that problem.