### PR TITLE
PMM-4906 PMM-4541 Skip system collections and databases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "mongodb_exporter"]
 	path = sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
 	url = https://github.com/percona/mongodb_exporter.git
-	branch = 0.10.0
+	branch = PMM-4906-add-flag-for-skipping-metrics-collection
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
 	url = https://github.com/percona/postgres_exporter


### PR DESCRIPTION
- https://jira.percona.com/browse/PMM-4906
- https://jira.percona.com/browse/PMM-4541

Add a flag to mongodb_exporter that allows to skip metrics collection from specified collections and dbs. Decrease related error messages log level.

- [x] https://github.com/percona/mongodb_exporter/pull/177