### PR TITLE
PMM-2717 Removed lock metrics for mongoDB 3.6+

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "mongodb_exporter"]
 	path = sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
 	url = https://github.com/percona/mongodb_exporter.git
-	branch = 0.10.0
+	branch = master
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
 	url = https://github.com/percona/postgres_exporter


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-2717

Skip locks metrics collection for MongoDB 3.6+

- [x] https://github.com/percona/pmm-managed/pull/318