### PR TITLE
PMM-5317 Skip unavailable metrics scrape on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,7 +53,7 @@
 [submodule "pmm-managed"]
 	path = sources/pmm-managed/src/github.com/percona/pmm-managed
 	url = https://github.com/percona/pmm-managed
-	branch = PMM-2.0
+	branch = PMM-5317-skip-unavailbale-metrics-on-macos
 [submodule "qan-api2"]
 	path = sources/qan-api2/src/github.com/percona/qan-api2
 	url = https://github.com/percona/qan-api2


### PR DESCRIPTION
- https://jira.percona.com/browse/PMM-5317

Don't grab unavailable on macOS node exporter metrics

- [x] https://github.com/percona/pmm-managed/pull/344