### PR TITLE
PMM-5719 Update Go to 1.13.10.

### DIFF
--- a/build/bin/build-client-packages
+++ b/build/bin/build-client-packages
@@ -538,7 +538,7 @@ if [ -n "$pmm_release" ]; then
 fi
 
 REVISION=0
-GO_TARBALL="https://dl.google.com/go/go1.12.12.linux-amd64.tar.gz"
+GO_TARBALL="https://dl.google.com/go/go1.13.10.linux-amd64.tar.gz"
 parse_arguments PICK-ARGS-FROM-ARGV "$@"
 get_system
 install_deps

--- a/build/bin/build-server-rpm
+++ b/build/bin/build-server-rpm
@@ -237,13 +237,6 @@ build() {
                 sudo yum -y install nodejs
                 sudo sed -i 's|SRPMS|x86_64|g' /etc/yum.repos.d/nodesource-el7.repo
 
-                sudo rm -rf /usr/local/go
-                wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz
-                sudo tar -C /usr/local -xzf go1.13.1.linux-amd64.tar.gz
-                sudo update-alternatives --install \"/usr/bin/go\" \"go\" \"/usr/local/go/bin/go\" 0
-                sudo update-alternatives --set go /usr/local/go/bin/go
-                sudo go version
-
                 sudo yum-builddep -y SOURCES/${spec_name}.spec
 
                 spectool -C SOURCES -g SOURCES/${spec_name}.spec

--- a/build/bin/prepare-node-modules
+++ b/build/bin/prepare-node-modules
@@ -41,12 +41,6 @@ update_grafana_node_modules() {
         sudo yum clean all
         sudo yum -y install nodejs
 
-        wget https://dl.google.com/go/go1.12.12.linux-amd64.tar.gz
-        sudo tar -C /usr/local -xzf go1.12.12.linux-amd64.tar.gz
-        sudo update-alternatives --install \"/usr/bin/go\" \"go\" \"/usr/local/go/bin/go\" 0
-        sudo update-alternatives --set go /usr/local/go/bin/go
-        sudo go version
-
         sudo npm --verbose install -g yarn
         rm -rf BUILD/grafana-*
         sudo chown builder:builder SOURCES/grafana-*

--- a/build/rpmbuild-docker/Dockerfile
+++ b/build/rpmbuild-docker/Dockerfile
@@ -21,7 +21,7 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
 RUN yum -y remove nodesource-release-el7-1.noarch
 RUN yum clean all && rm -rf /var/cache/yum
 
-ENV GO_VERSION 1.13.8
+ENV GO_VERSION 1.13.10
 ENV GO_CHECKSUM 0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8
 
 RUN wget --progress=dot:giga https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -O /tmp/golang.tar.gz

--- a/build/rpmbuild-docker/Dockerfile
+++ b/build/rpmbuild-docker/Dockerfile
@@ -22,7 +22,7 @@ RUN yum -y remove nodesource-release-el7-1.noarch
 RUN yum clean all && rm -rf /var/cache/yum
 
 ENV GO_VERSION 1.13.10
-ENV GO_CHECKSUM 0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8
+ENV GO_CHECKSUM 8a4cbc9f2b95d114c38f6cbe94a45372d48c604b707db2057c787398dfbf8e7f
 
 RUN wget --progress=dot:giga https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -O /tmp/golang.tar.gz
 RUN sha256sum /tmp/golang.tar.gz


### PR DESCRIPTION
It also exterminates copy&pasted Go installation commands.

Should be merged after #128.