### PR TITLE
PMM-5719 [FB] on-demand golang installation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,7 @@
 [submodule "pmm-server-packaging"]
 	path = sources/pmm-server-packaging
 	url = https://github.com/percona/pmm-server-packaging
-	branch = PMM-2.0
+	branch = PMM-5719_on-demand_go_installation
 [submodule "grafana-dashboards"]
 	path = sources/grafana-dashboards
 	url = https://github.com/percona/grafana-dashboards


### PR DESCRIPTION
Install golang as build dep, only if needed.
---
Dependent PR's:
- [ ] [pmm-server-packaging](https://github.com/percona/pmm-server-packaging/pull/128)