### PR TITLE
PMM-5645 [PMM2] Fix permissions for specs

### DIFF
--- a/build/bin/build-server-rpm
+++ b/build/bin/build-server-rpm
@@ -49,6 +49,7 @@ prepare_specs() {
     local spec_name=$1
     local repo_name=$2
 
+    sudo chown -R $(id -u):$(id -g) ${rpmbuild_dir}/SPECS ${rpmbuild_dir}/SOURCES
     cp ${rpmbuild_dir}/SPECS/${spec_name}.spec ${rpmbuild_dir}/SOURCES/${spec_name}.spec
     if [ -d "${root_dir}/sources/${repo_name}" ]; then
         local git_dir=$(dirname $(find "${root_dir}/sources/${repo_name}" -name .git | head -1))


### PR DESCRIPTION
Fixes problem with permissions due build:
```
+ cp /mnt/workspace/pmm-submodules_PR-926/sources/pmm-server-packaging/rhel/SPECS/grafana.spec /mnt/workspace/pmm-submodules_PR-926/sources/pmm-server-packaging/rhel/SOURCES/grafana.spec
cp: cannot create regular file ‘/mnt/workspace/pmm-submodules_PR-926/sources/pmm-server-packaging/rhel/SOURCES/grafana.spec’: Permission denied
script returned exit code 1
```