### PR TITLE
[FB] PMM-6516 fixed clickhouse build version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,7 +78,7 @@
 [submodule "pmm-server-packaging"]
 	path = sources/pmm-server-packaging
 	url = https://github.com/percona/pmm-server-packaging
-	branch = PMM-2.0
+	branch = PMM-6516_fix_clickhouse_build_version
 [submodule "grafana-dashboards"]
 	path = sources/grafana-dashboards
 	url = https://github.com/percona/grafana-dashboards


### PR DESCRIPTION
Related PRs:
- [pmm-server-packaging](https://github.com/percona/pmm-server-packaging/pull/158)

This PR fixes error that block [PR-1042 -- PMM-6410 errexit & xtrace](https://github.com/Percona-Lab/pmm-submodules/pull/1042).