### PR TITLE
PMM-6389 Build percona-victoriametrics rpm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,6 +232,7 @@ pipeline {
                             # 3rd-party
                             build-server-rpm clickhouse
                             build-server-rpm prometheus
+                            build-server-rpm victoriametrics
                             build-server-rpm alertmanager
                             build-server-rpm grafana
                         "

--- a/build/bin/build-server
+++ b/build/bin/build-server
@@ -26,6 +26,7 @@ ${bin_dir}/build-server-rpm dbaas-tools
 # 3rd-party
 ${bin_dir}/build-server-rpm clickhouse
 ${bin_dir}/build-server-rpm prometheus
+${bin_dir}/build-server-rpm victoriametrics
 ${bin_dir}/build-server-rpm alertmanager
 ${bin_dir}/build-server-rpm grafana
 


### PR DESCRIPTION
The same as https://github.com/Percona-Lab/pmm-submodules/pull/1020 , but without `.gitmodules` changes.