### PR TITLE
Updated Makefile to show help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,28 @@
-all: client server
+.PHONY: all submodules server client clean purge test help default
 
-submodules:
+default: help
+
+help:                       ## Display this help message.
+	@echo "Please use \`make <target>\` where <target> is one of:"
+	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | \
+	awk -F ':.*?## ' 'NF==2 {printf "  %-26s%s\n", $$1, $$2}'
+
+all: client server          ## Build client and server.
+
+submodules:                 ## Update all sumodules .
 	git submodule update --init --remote --jobs 10
 	git submodule status
 
-server:
+server:                     ## Build the server.
 	./build/bin/build-server
 
-client:
+client:                     ## Build the client.
 	./build/bin/build-client
 
-clean:
+clean:                      ## Clean build results.
 	rm -rf tmp results sources/pmm-submodules
 
-purge:
+purge:                      ## Clean cache and leftovers. Please run this when starting a new feature build.
 	git reset --hard && git clean -xdff
 	git submodule update
 	git submodule foreach 'git reset --hard && git clean -xdff'


### PR DESCRIPTION
This PR only adds help as the default command for `make`.
It is just to make it easy to realize that there are functions like purge that should be run when starting a new feasture build. 
Sample output:
```
Please use `make <target>` where <target> is one of:
  help                      Display this help message.
  all                       Build client and server
  submodules                Update all sumodules
  server                    Build the server
  client                    Build the client
  clean                     Clean build results
  purge                     Clean cache and leftovers. Please run this when starting a new feature build.
```