### PR TITLE
PMM-2.16 Including PMM-7689 and PMM-7128

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "mongodb_exporter"]
 	path = sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
 	url = https://github.com/percona/mongodb_exporter.git
-	branch = release-0.20.3
+	branch = release-0.20.4
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
 	url = https://github.com/percona/postgres_exporter


### PR DESCRIPTION
**mongodb_exporter** is using branch **release-0.20.4** which derives from current master with [PMM-7689](https://jira.percona.com/browse/PMM-7689) and [PMM-7128](https://jira.percona.com/browse/PMM-7128) already merged.