### PR TITLE
PMM-6278 [FB] Explain DML queries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "pmm-agent"]
 	path = sources/pmm-agent/src/github.com/percona/pmm-agent
 	url = https://github.com/percona/pmm-agent.git
-	branch = master
+	branch = PMM_6278-Explain_dml
 [submodule "node_exporter"]
 	path = sources/node_exporter/src/github.com/prometheus/node_exporter
 	url = https://github.com/percona/node_exporter.git


### PR DESCRIPTION
Jira: [PMM-6278 Explain not showing for DELETE queries](https://jira.percona.com/browse/PMM-6278)

Only newer MySQL versions are able to run explain on DML queries but even if it is possible to run explain, it requieres more permissions than the ones we require for the connection user.
For example, to explain a `DROP TABLE` you should have drop permissions. 
This PR implements the same query transform funtions we have in Percona Toolkit and in PMM v1 that convert DML queries to the equivalent SELECTs when possible.
We only convert `INSERT`, `UPDATE` and `DELETE` queries. 
All other queries will be trated as usual thus, explain will return an error. 