### PR TITLE
PMM-7584 Components: Update VictoriaMetrics 1.53.1 to 1.60.0

### DIFF
--- a/build/bin/vars
+++ b/build/bin/vars
@@ -41,5 +41,5 @@ docker_client_tarball=${root_dir}/results/docker/pmm2-client-${pmm_version}.dock
 source_tarball=${root_dir}/results/source_tarball/pmm2-client-${pmm_version}.tar.gz
 binary_tarball=${root_dir}/results/tarball/pmm2-client-${pmm_version}.tar.gz
 
-# https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-v1.50.2
-vmagent_commit_hash=85933589654a84c4d2f50436761461a87c706d79
+# https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-v1.60.0
+vmagent_commit_hash=e49bf9bc73c3a83f510578ef20fc9bd52d02aad5


### PR DESCRIPTION
- [ ] https://github.com/Percona-Lab/pmm-submodules/pull/1826
- [ ] https://github.com/percona/pmm-server/pull/266