### PR TITLE
remove pmm-api-tests submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -84,10 +84,6 @@
 	branch = master
 
 ## PMM Tests
-[submodule "pmm-api-tests"]
-	path = sources/pmm-api-tests/src/github.com/Percona-Lab/pmm-api-tests
-	url = https://github.com/Percona-Lab/pmm-api-tests
-	branch = master
 [submodule "pmm-qa"]
 	path = sources/pmm-qa/src/github.com/percona/pmm-qa
 	url = https://github.com/percona/pmm-qa


### PR DESCRIPTION
As I understand we don't need it anymore. We moved tests to pmm-managed.