### PR TITLE
PMM-8539 [FB] Fixed cluster role label

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "mongodb_exporter"]
 	path = sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
 	url = https://github.com/percona/mongodb_exporter.git
-	branch = release-0.20.6
+	branch = PMM-8539_cluster_role_label
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
 	url = https://github.com/percona/postgres_exporter


### PR DESCRIPTION
Fixed following specs in https://jira.percona.com/browse/PMM-6494.

Cluster role - "shardsvr", "configsvr", "mongos" or "".
Set "mongos" if there is a sharding.configDB config value set.
For others whatever the value for sharding.clusterRole is.
It will be empty when a non-sharded replicaset or standalone mongod nod