### PR TITLE
PMM-8849 Fixed panic on timeout

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,6 @@
+deps:
+- name: mongodb_exporter
+  branch: PMM-8849_panic_on_timeout
+  path: sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
+  url: https://github.com/percona/mongodb_exporter.git
+  component: client


### PR DESCRIPTION
[PMM-8004](https://jira.percona.com/browse/PMM-8004) mongodb_exporter v0.20.4 - SIGSEGV while monitoring mongos 4.2.12 Community
Related also to [PMM-8849: DBaaS: No metrics for MongoDB clusters](https://jira.percona.com/browse/PMM-8849)

See how to test in *PMM-8004*