### PR TITLE
PMM-8851 [FB] Fix Postgres DSN string

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,7 @@
+deps:
+# SERVER
+- name: pmm-managed
+  branch: PMM-8851_pg_ssl
+  path: sources/pmm-managed/src/github.com/percona/pmm-managed
+  url: https://github.com/percona/pmm-managed
+  component: server


### PR DESCRIPTION
Now the Postgres DSN uses verify-ca instead of verify-full for users using certs with IP addresses.
How to test in jira [PMM-8851](https://jira.percona.com/browse/PMM-8851)