### PR TITLE
PMM-8874 Updated modules for PMM 2.23

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
 	url = https://github.com/percona/postgres_exporter
-	branch = release-0.4.8
+	branch = master
 [submodule "clickhouse_exporter"]
 	path = sources/clickhouse_exporter/src/github.com/Percona-Lab/clickhouse_exporter
 	url = https://github.com/Percona-Lab/clickhouse_exporter

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,11 +25,11 @@
 [submodule "mongodb_exporter"]
 	path = sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
 	url = https://github.com/percona/mongodb_exporter.git
-	branch = release-0.20.6
+	branch = release-0.20.8
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
 	url = https://github.com/percona/postgres_exporter
-	branch = master
+	branch = release-0.4.8
 [submodule "clickhouse_exporter"]
 	path = sources/clickhouse_exporter/src/github.com/Percona-Lab/clickhouse_exporter
 	url = https://github.com/Percona-Lab/clickhouse_exporter
@@ -49,7 +49,7 @@
 [submodule "percona-toolkit"]
 	path = sources/percona-toolkit/src/github.com/percona/percona-toolkit
 	url = https://github.com/percona/percona-toolkit.git
-	branch = release-3.2.1
+	branch = release-3.3.2
 
 
 # PMM Server


### PR DESCRIPTION
Updated mongodb_exporter, postgres_exporter and toolkit.
Not included yet because we didn't talk about creating a new release for these exporters.

- proxysql_exporter: release-1.1.2
- rds_exporter: release-0.7.2

I made the branches with the changes. Not need to test because they are based on the corresponding master braches but there were not official releases for proxysql_exporter rds_exporter even when we have changes.