### PR TITLE
Revert "PMM-9407 Add queries.yaml to debian package to postgres medium-resolution path"

### DIFF
--- a/build/bin/build-client-packages
+++ b/build/bin/build-client-packages
@@ -444,7 +444,6 @@ build_source_deb(){
     mv queries-mysqld-group-replication.yml ../${NAME}-${VERSION}_all/distro/
     mv example-queries-postgres.yml ../${NAME}-${VERSION}_all/distro/
     mv queries-postgres-uptime.yml ../${NAME}-${VERSION}_all/distro/
-    mv queries.yaml ../${NAME}-${VERSION}_all/distro/
     mv debian ../${NAME}-${VERSION}_all/
     mv config/pmm-agent.service ../${NAME}-${VERSION}_all/debian/pmm2-client.pmm-agent.service
     cd ../

--- a/build/debian/files
+++ b/build/debian/files
@@ -51,4 +51,3 @@ install -m 0660 example-queries-postgres.yml $RPM_BUILD_ROOT/usr/local/percona/p
 install -m 0660 example-queries-postgres.yml $RPM_BUILD_ROOT/usr/local/percona/pmm2/collectors/custom-queries/postgresql/medium-resolution/
 install -m 0660 example-queries-postgres.yml $RPM_BUILD_ROOT/usr/local/percona/pmm2/collectors/custom-queries/postgresql/high-resolution/
 install -m 0660 queries-postgres-uptime.yml $RPM_BUILD_ROOT/usr/local/percona/pmm2/collectors/custom-queries/postgresql/high-resolution/
-install -m 0660 queries.yaml $RPM_BUILD_ROOT/usr/local/percona/pmm2/collectors/custom-queries/postgresql/medium-resolution/

--- a/build/debian/install
+++ b/build/debian/install
@@ -23,4 +23,3 @@ example-queries-postgres.yml /usr/local/percona/pmm2/collectors/custom-queries/p
 example-queries-postgres.yml /usr/local/percona/pmm2/collectors/custom-queries/postgresql/medium-resolution/
 example-queries-postgres.yml /usr/local/percona/pmm2/collectors/custom-queries/postgresql/high-resolution/
 queries-postgres-uptime.yml /usr/local/percona/pmm2/collectors/custom-queries/postgresql/high-resolution/
-queries.yaml /usr/local/percona/pmm2/collectors/custom-queries/postgresql/medium-resolution/

--- a/build/debian/rules
+++ b/build/debian/rules
@@ -62,7 +62,6 @@ override_dh_auto_install:
 	cp -f distro/queries-mysqld-group-replication.yml $(TMP)/queries-mysqld-group-replication.yml
 	cp -f distro/example-queries-postgres.yml $(TMP)/example-queries-postgres.yml
 	cp -f distro/queries-postgres-uptime.yml $(TMP)/queries-postgres-uptime.yml
-	cp -f distro/queries.yaml $(TMP)/queries.yaml
 	cp -f distro/pt-summary $(TMP)/pt-summary
 	cp -f distro/pt-mysql-summary $(TMP)/pt-mysql-summary
 	cp -f distro/pt-mongodb-summary $(TMP)/pt-mongodb-summary


### PR DESCRIPTION
[PMM-9021](https://jira.percona.com/browse/PMM-9021) found that we have critical issue - we need to roll back this feature from 2.26.0