### PR TITLE
PMM-9413 Deadlock during agent addition/removal in pmm-managed

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,7 @@
+deps:
+# SERVER
+- name: pmm-managed
+  branch: PMM-9413-fix-deadlock
+  path: sources/pmm-managed/src/github.com/percona/pmm-managed
+  url: https://github.com/percona/pmm-managed
+  component: server


### PR DESCRIPTION
[PMM-9413](https://jira.percona.com/browse/PMM-9413) : A deadlock occurs when a goroutine waits to acquire an already acquired lock. This bug breaks functionality for adding or removing agents from PMM server.

This PR generates a feature build for fix to above bug.