### PR TITLE
PMM-9306-update-victoria-metrics-to-1.72.0 (FB)

### DIFF
--- a/build/bin/vars
+++ b/build/bin/vars
@@ -49,5 +49,5 @@ docker_client_tarball=${root_dir}/results/docker/pmm2-client-${pmm_version}.dock
 source_tarball=${root_dir}/results/source_tarball/pmm2-client-${pmm_version}.tar.gz
 binary_tarball=${root_dir}/results/tarball/pmm2-client-${pmm_version}.tar.gz
 
-# https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-v1.60.0
-vmagent_commit_hash=e49bf9bc73c3a83f510578ef20fc9bd52d02aad5
+# https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-v1.72.0
+vmagent_commit_hash=e1668e744136dfa82f29761a624420f9d85b2108

--- a/ci.yml
+++ b/ci.yml
@@ -1,3 +1,0 @@
-deps:
-- name: pmm-server
-  branch: PMM-9306-update-victoria-metrics-to-1.72.0

--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+- name: pmm-server
+  branch: PMM-9306-update-victoria-metrics-to-1.72.0


### PR DESCRIPTION
[PMM-9306](https://jira.percona.com/browse/PMM-9306) : Updating version VictoriaMetrics and vmagent.