### PR TITLE
PMM-9445 Enable MongoDB UI tests

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,7 @@
+deps:
+# QA
+- name: pmm-ui-tests
+  branch: PMM-9445-Fix-MongoDB-Exporter-test-issue
+  path: sources/pmm-ui-tests/src/github.com/percona/pmm-ui-tests
+  url: https://github.com/percona/pmm-ui-tests
+  component: qa

--- a/ci.yml
+++ b/ci.yml
@@ -1,7 +1,7 @@
 deps:
 # QA
 - name: pmm-ui-tests
-  branch: PMM-9445-Fix-MongoDB-Exporter-test-issue
+  branch: PMM-9445-Enable-MongoDB-UI-tests
   path: sources/pmm-ui-tests/src/github.com/percona/pmm-ui-tests
   url: https://github.com/percona/pmm-ui-tests
   component: qa


### PR DESCRIPTION
Enable UI tests for MongoDB. They were disabled due to issue with MongoDB exporter earlier.