### PR TITLE
Update Prometheus client library

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm-agent
+    branch: update-prometheus-client
+


### PR DESCRIPTION
Updates prometheus client due to [CVE-2022-21698](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2022-21698) which causes [failure in WhiteSource security checks](https://github.com/percona/pmm-agent/pull/325/checks?check_run_id=5396661370).

- [ ] https://github.com/percona/pmm-agent/pull/326
