### PR TITLE
PMM-8434 [FB] PMM Public address from env var

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,7 @@
+deps:
+# SERVER
+- name: pmm-managed
+  branch: PMM-8434-public_address_env
+  path: sources/pmm-managed/src/github.com/percona/pmm-managed
+  url: https://github.com/percona/pmm-managed
+  component: server


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-8434 PMM Server Public Address could be passed as environment variable

This patch allows setting the value for the PMM public address from the environment. It will be used in cases like un K8s where when the container is started, the DNS server is already started and we know the server address.

[pmm_managed fix: PMM-8434 PMM public address from env #1013
](https://github.com/percona/pmm-managed/pull/1013)
