### PR TITLE
Fixes for local builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,10 @@
 
 # PMM Client
 
+[submodule "vmagent"]
+	path = sources/vmagent/src/github.com/VictoriaMetrics/VictoriaMetrics
+	url = https://github.com/VictoriaMetrics/VictoriaMetrics.git
+	branch = main
 [submodule "pmm-admin"]
 	path = sources/pmm-admin/src/github.com/percona/pmm-admin
 	url = https://github.com/percona/pmm-admin.git

--- a/build/bin/build-server-rpm
+++ b/build/bin/build-server-rpm
@@ -24,18 +24,20 @@ is_build_needed() {
     local spec_name=$1
     local rpm_version=$2
 
-    if [ -n "$RPM_EPOCH" ]; then
-        aws s3 sync \
-            --region us-east-2 \
-            --no-sign-request \
-            s3://pmm-build-cache/PR-BUILDS/${spec_name}-${rpm_version} \
-            ${rpms_dir}/${spec_name}-${rpm_version}
-    else
-        aws s3 sync \
-            --region us-east-2 \
-            --no-sign-request \
-            s3://pmm-build-cache/${spec_name}-${rpm_version} \
-            ${rpms_dir}/${spec_name}-${rpm_version}
+    if [ "$cache" != "false" ]; then
+        if [ -n "$RPM_EPOCH" ]; then
+            aws s3 sync \
+                --region us-east-2 \
+                --no-sign-request \
+                s3://pmm-build-cache/PR-BUILDS/${spec_name}-${rpm_version} \
+                ${rpms_dir}/${spec_name}-${rpm_version}
+        else
+            aws s3 sync \
+                --region us-east-2 \
+                --no-sign-request \
+                s3://pmm-build-cache/${spec_name}-${rpm_version} \
+                ${rpms_dir}/${spec_name}-${rpm_version}
+        fi
     fi
 
     # pmm-server package is always build due to included swagger folder from the repo pmm
@@ -128,18 +130,20 @@ build() {
         "
 
 
-        if [ -n "$RPM_EPOCH" ]; then
-            aws s3 sync \
-                --region us-east-2 \
-                ${rpms_dir}/${spec_name}-${rpm_version} \
-                s3://pmm-build-cache/PR-BUILDS/${spec_name}-${rpm_version} \
-                || :
-        else
-            aws s3 sync \
-                --region us-east-2 \
-                ${rpms_dir}/${spec_name}-${rpm_version} \
-                s3://pmm-build-cache/${spec_name}-${rpm_version} \
-                || :
+        if [ "$cache" != "false" ]; then
+            if [ -n "$RPM_EPOCH" ]; then
+                aws s3 sync \
+                    --region us-east-2 \
+                    ${rpms_dir}/${spec_name}-${rpm_version} \
+                    s3://pmm-build-cache/PR-BUILDS/${spec_name}-${rpm_version} \
+                    || :
+            else
+                aws s3 sync \
+                    --region us-east-2 \
+                    ${rpms_dir}/${spec_name}-${rpm_version} \
+                    s3://pmm-build-cache/${spec_name}-${rpm_version} \
+                    || :
+            fi
         fi
     fi
 }

--- a/build/bin/build-server-rpm
+++ b/build/bin/build-server-rpm
@@ -24,7 +24,7 @@ is_build_needed() {
     local spec_name=$1
     local rpm_version=$2
 
-    if [ "$cache" != "false" ]; then
+    if [ "$cache" == "auto" ] && [ type -P aws ]; then
         if [ -n "$RPM_EPOCH" ]; then
             aws s3 sync \
                 --region us-east-2 \
@@ -130,7 +130,7 @@ build() {
         "
 
 
-        if [ "$cache" != "false" ]; then
+        if [ "$cache" == "auto" ] && [ type -P aws ]; then
             if [ -n "$RPM_EPOCH" ]; then
                 aws s3 sync \
                     --region us-east-2 \

--- a/build/bin/vars
+++ b/build/bin/vars
@@ -3,7 +3,9 @@ root_dir=$(cd $(dirname $0)/../..; pwd -P)
 tmp_dir=${root_dir}/tmp
 
 # Use s3 cache for PMM server build (build-server-rpm)
-cache=${CACHE:-false}
+# Defaults to autodetect for awscli, using it to download cache if found
+# Change to "false" to disable cache
+cache=${CACHE:-auto}
 
 # In VERSION file we can have numeric value like '2.0.0' as well as
 # alphanumeric value like '2.0.0-alpha3' which we can not be used entirely

--- a/build/bin/vars
+++ b/build/bin/vars
@@ -2,6 +2,9 @@ bin_dir=$(cd $(dirname $0); pwd -P)
 root_dir=$(cd $(dirname $0)/../..; pwd -P)
 tmp_dir=${root_dir}/tmp
 
+# Use s3 cache for PMM server build (build-server-rpm)
+cache=${CACHE:-false}
+
 # In VERSION file we can have numeric value like '2.0.0' as well as
 # alphanumeric value like '2.0.0-alpha3' which we can not be used entirely
 # e.g. in Version directive in spec files. So we define:


### PR DESCRIPTION
Trying to get local builds working for people outside of Percona. Here's a couple of initial steps, which fix an initial build failure on pmm-client when a VictoriaMetrics submodule did not exist, and disable the S3 private cache by default (while creating a CACHE setting to enable it) — which was mandatory in build-server-rpm.