### PR TITLE
PMM-9350 [FB] Upgrade jwt-go

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,13 @@
+deps:
+  # COMMON
+  - name: proxysql_exporter
+    branch: main
+    path: PMM-9350_Upgrade_go-jwt
+    url: https://github.com/percona/proxysql_exporter
+    component: client
+
+  - name: pmm-agent
+    branch: main
+    path: PMM-9350_Upgrade_go-jwt
+    url: https://github.com/percona/pmm-agent
+    component: client


### PR DESCRIPTION
[PMM-9350](https://jira.percona.com/browse/PMM-9350) Migrate to golang-jwt
Upgraded **reviewdog** since it uses `github.com/dgrijalva/jwt-go` which had a vulnerability.

- [ ] [pmm-agent #350](https://github.com/percona/pmm-agent/pull/350)
- [ ] [proxysql exporter #60](https://github.com/percona/proxysql_exporter/pull/60)
- [ ] [promconfig #13](https://github.com/percona/promconfig/pull/13) **Not used in this PR**
