### PR TITLE
2.26.0-with-no-tls-verification

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm-managed
+    branch: 2.26.0-with-no-tls-verification


### PR DESCRIPTION
includes changes from https://github.com/percona/pmm-managed/tree/2.26.0-with-no-tls-verification