### PR TITLE
PMM-4879 Support for defaults file parameter.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,19 @@
+deps:
+  # COMMON
+  - name: pmm
+    url: https://github.com/pkadej/pmm
+    branch: PMM-4879-mysql-add-defaults-file
+
+  # CLIENT
+  - name: pmm-admin
+    url: https://github.com/pkadej/pmm-admin
+    branch: PMM-4879-defaults-file
+
+  - name: pmm-agent
+    url: https://github.com/pkadej/pmm-agent
+    branch: PMM-4879-defaults-file
+
+  # SERVER
+  - name: pmm-managed
+    url: https://github.com/pkadej/pmm-managed
+    branch: PMM-4879-defaults-file


### PR DESCRIPTION
[PMM-4879](https://jira.percona.com/browse/PMM-4879)

- [pmm](https://github.com/percona/pmm/pull/863)
- [pmm-admin](https://github.com/percona/pmm-admin/pull/199)
- [pmm-managed](https://github.com/percona/pmm-managed/pull/1068)
- [pmm-agent](https://github.com/percona/pmm-agent/pull/356)

Build will fail because I cannot use forked version of api (pmm) as dependency in mod.go. To acomplish this, api needs be merged and version of pmm api should be bumped.