### PR TITLE
PMM-9922 Define permissions required for GITHUB_API_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ git push
 
 Given that github is limiting the number of API requests for unauthenticated users, it'd be a good idea to use your personal access token. You can create a personal token in [Github settings](https://github.com/settings/tokens). Generate New Token -> Click on a repo -> Create an environment variable called GITHUB_TOKEN and provide your token as the value.
 
+The token requires the following permissions:
+* `repo:status`
+* `public_repo`
+* `read:user`
+
+It is recommended to set an expiration date for your token.
+
 if you use zsh:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git push
 
 ## Using a Personal Access Token (PAT)
 
-Given that github is limiting the number of API requests for unauthenticated users, it'd be a good idea to use your personal access token. You can create a personal token in [Github settings](https://github.com/settings/tokens). Generate New Token -> Click on a repo -> Create an environment variable called GITHUB_TOKEN and provide your token as the value.
+Given that github is limiting the number of API requests for unauthenticated users, it'd be a good idea to use your personal access token. You can create a personal token in [Github settings](https://github.com/settings/tokens). Generate New Token -> Click on a repo -> Create an environment variable called `GITHUB_API_TOKEN` and provide your token as the value.
 
 The token requires the following permissions:
 * `repo:status`
@@ -55,14 +55,14 @@ It is recommended to set an expiration date for your token.
 if you use zsh:
 
 ```console
-echo 'export GITHUB_TOKEN=********' >> ~/.zshrc
+echo 'export GITHUB_API_TOKEN=********' >> ~/.zshrc
 source ~/.zshrc
 ```
 
 if you use bash:
 
 ```console
-echo 'export GITHUB_TOKEN=********' >> ~/.bash_profile
+echo 'export GITHUB_API_TOKEN=********' >> ~/.bash_profile
 source ~/.bash_profile
 ```
 


### PR DESCRIPTION
Updating the README to add the permissions required when creating
a new personal access token for GitHub.

https://jira.percona.com/browse/PMM-9922
