### PR TITLE
PMM-9999 upgrade victoriametrics to 1.77.1 (FB)

### DIFF
--- a/build/bin/vars
+++ b/build/bin/vars
@@ -49,5 +49,5 @@ docker_client_tarball=${root_dir}/results/docker/pmm2-client-${pmm_version}.dock
 source_tarball=${root_dir}/results/source_tarball/pmm2-client-${pmm_version}.tar.gz
 binary_tarball=${root_dir}/results/tarball/pmm2-client-${pmm_version}.tar.gz
 
-# https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-v1.76.1
-vmagent_commit_hash=095feeee414281455193b712f60d7aed13c6dff1
+# https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-v1.77.1
+vmagent_commit_hash=2685992ca913dab8391aae6b0416e4b64c5bbf87

--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm-server
+    branch: PMM-9999-upgrade-vm-to-1.77.1


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-9999

This is the feature build that contains changes from pmm-server. A separate PR to update the VM version used in the pmm-submodules repo is at https://github.com/Percona-Lab/pmm-submodules/pull/2520

- [ ] https://github.com/percona/pmm-server/pull/360