### PR TITLE
PMM-9965 [FB] Remove VM operator

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,14 @@
+deps:
+  # SERVER
+  - name: pmm-managed
+    branch: PMM-9965-Remove_vm_operator
+    path: sources/pmm-managed/src/github.com/percona/pmm-managed
+    url: https://github.com/percona/pmm-managed
+    component: server
+
+  - name: dbaas-controller
+    branch: PMM-9965-Remove_vm_operator
+    path: sources/dbaas-controller/src/github.com/percona-platform/dbaas-controller
+    url: https://github.com/percona-platform/dbaas-controller
+    component: server
+


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-9965

When the DB cluster is removed, the Victoria Metrics operator should be removed.
This adds the remove functionality to the API so removing a cluster and reinstalling it shouldn't throw an error