### PR TITLE
PMM-10012 [FB] DBaaS: cannot create PSMDB cluster with 1.12 operator

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,6 @@
+deps:
+  - name: dbaas-controller
+    branch: PMM-10012_psmdb_1_11_plus_b
+    path: sources/dbaas-controller/src/github.com/percona-platform/dbaas-controller
+    url: https://github.com/percona-platform/dbaas-controller
+    component: server


### PR DESCRIPTION
[PMM-10012](https://jira.percona.com/browse/PMM-10012) DBaaS: cannot create PSMDB cluster with 1.12 operator
