### PR TITLE
PMM-10180: disable http compression by default with experimental PG exporter

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm-managed
+    branch: PMM-10180-disable-http-compression

--- a/ci.yml
+++ b/ci.yml
@@ -1,3 +1,5 @@
 deps:
   - name: pmm-managed
     branch: PMM-10180-disable-http-compression
+  - name: postgres_exporter
+    branch: PMM-7806-upgrade-pg-exporter

--- a/ci.yml
+++ b/ci.yml
@@ -1,5 +1,5 @@
 deps:
-  - name: pmm-managed
+  - name: pmm
     branch: PMM-10180-disable-http-compression
   - name: postgres_exporter
     branch: PMM-7806-upgrade-pg-exporter-experimental

--- a/ci.yml
+++ b/ci.yml
@@ -2,4 +2,4 @@ deps:
   - name: pmm-managed
     branch: PMM-10180-disable-http-compression
   - name: postgres_exporter
-    branch: PMM-7806-upgrade-pg-exporter
+    branch: PMM-7806-upgrade-pg-exporter-experimental


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10180

- https://github.com/percona/pmm-managed/pull/1157
- https://github.com/percona/promconfig/pull/14
- https://github.com/percona/postgres_exporter/pull/69

[contains experimental improvements](https://github.com/percona/postgres_exporter/pull/69/commits/c1b534d43496e4c3d4535e6c879e0660dd328efd):
 - includes pprof
 - sync scrape
 - minor perf tweaks 
