### PR TITLE
PMM-9985: fix workflow

### DIFF
--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -12,35 +12,35 @@ on:
 
 jobs:
 
-  setup:
+  helm-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: percona-platform/checkout@v3
+
+      - name: checkout code
+        uses: percona-platform/checkout@v3
         with:
           submodules: 'recursive'
-      - uses: percona-platform/setup-node@v3
+
+      - name: install npm
+        uses: percona-platform/setup-node@v3
         with:
           node-version: '14'
-      - run: npm install -g bats
 
-  minikube_start:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          ls -la
-          ls -la ./sources/pmm-qa/src/github.com/percona/pmm-qa/pmm-tests/
-          ./sources/pmm-qa/src/github.com/percona/pmm-qa/pmm-tests/install_k8s_tools.sh --minikube
+      - name: install tools
+        run: |
+          npm install -g bats
+          ./sources/pmm-qa/src/github.com/percona/pmm-qa/pmm-tests/install_k8s_tools.sh --minikube --helm --kubectl --user
+
+      - name: minikube_start
+        run: |
           minikube start
+          kubectl wait --for=condition=Ready node --timeout=90s minikube
 
-  helm_tests:
-    needs: minikube_start
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          cd ./sources/pmm-qa/src/github.com/percona/pmm-qa/pmm-tests/
-          
-          ./install_k8s_tools.sh --helm --kubectl
+      - name: helm_tests
+        run: |
+          echo $(git submodule status)
+
+          cd /home/runner/work/pmm-submodules/pmm-submodules/sources/pmm-qa/src/github.com/percona/pmm-qa/pmm-tests/
           
           export IMAGE_REPO=$(echo $SERVER_IMAGE | cut -d ':' -f 1)
           export IMAGE_TAG=$(echo $SERVER_IMAGE | cut -d ':' -f 2)


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-9985

this fixes new workflow:
- steps instead of jobs (jobs are isolated)
- wait for minikube to start, if node isn't ready waiting for pod would fail as there would be no resource like that

also needs:
https://github.com/percona/pmm-qa/pull/489