### PR TITLE
PMM-10012 [FB] Support for PSMDB operator 1.11+

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,13 @@
+deps:
+  # COMMON
+  - name: pmm
+    branch: PMM-10012_psmdb_1_11_plus_b
+    path: sources/pmm/src/github.com/percona/pmm
+    url: https://github.com/percona/pmm
+    component: common
+
+  - name: dbaas-controller
+    branch: PMM-10012_psmdb_1_11_plus_b
+    path: sources/dbaas-controller/src/github.com/percona-platform/dbaas-controller
+    url: https://github.com/percona-platform/dbaas-controller
+    component: server


### PR DESCRIPTION
[PMM-10012](https://jira.percona.com/browse/PMM-10012) DBaaS: cannot create PSMDB cluster with 1.12 operator
