### PR TITLE
PMM-7 add missing labels for postgres_exporter

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: postgres_exporter
+    branch: PMM-7-pg-missing-labels


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-7

- [postgres_exporter#75](https://github.com/percona/postgres_exporter/pull/75)
