### PR TITLE
PMM-10858-latest-version-fix

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm-update
+    branch: PMM-10858-latest-version-fix


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10858

**Show latest version at the time of initialization:**
Setting connection timeout to 1 second for EPEL repository, by default it is 30 seconds (same as supervisord default timeout). Because some of the mirrors weren't responding, it was causing supervisord to kill pmm-update-checker process.