### PR TITLE
PMM-10541: extend server gRPC metrics with caller_origin

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-10948-extend-server-metrics


### PR DESCRIPTION
Related PRs:
 - https://github.com/percona/pmm/pull/1398
 - https://github.com/Percona-Lab/go-grpc-prometheus/pull/3