### PR TITLE
PMM-11069 scheduled-backup-identical-names-allowed-fix FB.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-11069-scheduled-backup-identical-names-allowed-fix


### PR DESCRIPTION
Scheduled backup tasks with identical names allowed to create

- [ ] https://github.com/percona/pmm/pull/1411
