### PR TITLE
PMM-11038 Move to dbaas-operator FB

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-11038-dbaas-operator

--- a/ci.yml
+++ b/ci.yml
@@ -1,3 +1,7 @@
 deps:
   - name: pmm
     branch: PMM-11038-dbaas-operator
+  - name: dbaas-controller
+    branch: PMM-11024-percona-catalog
+  - name: grafana
+    branch: PMM-11031-advanced-settings-ui-dbaas


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-11038


Work is still in progress but FB is ready for testing and fixing issues by providing feedback. It uses dbaas-operator to create/manage/delete database clusters for PMM/DBaaS feature. 

Current features:

1. Extended API to create/edit database clusters. Added additional fields (engine configuration, internet facing, storage class, internet facing, source ranges (IP source ranges)
2. Once exposing PXC cluster on EKS by default it uses ip-nlb load balancer, however, when internet_facing is true it uses `external` load balancer type
3. Fixed bug when during import OOM killer kills PXC cluster
4. Added ability to override storage class via API
For additional fields, read `*.proto` filed changes [here](https://github.com/percona/pmm/pull/1413/files)

## Running and testing

1. Install feature build
2. Register k8s cluster to PMM/DBaaS
3. Install dbaas-operator

## installing dbaas-operator

Prerequisites
1. Go installed
2. Make installed 

1. git clone https://github.com/percona/dbaas-operator
3. Run `make build` - to build ./bin/manager
4. Run `make install` to install CRDs
5. Run `./bin/manager` to run the operator controller

Note: it uses default k8s cluster provided in `~/.kube/config`

## Known issues

1. PMM should not pass API keys for PMM via CRs
