### PR TITLE
PMM-7958 postgres databases cannot be deleted while monitored

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: postgres_exporter
+    branch: PMM-7958-postgres-databases-cannot-be-deleted-while-monitored


### PR DESCRIPTION
[PMM-7958](https://jira.percona.com/browse/PMM-7958)

- [PR](https://github.com/percona/postgres_exporter/pull/90) Links to relevant pull requests
- TODO: write tests in percona-qa
