### PR TITLE
PMM-10918 Feature build for DBaaS Backup/restore

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-10918-backup

--- a/ci.yml
+++ b/ci.yml
@@ -1,3 +1,5 @@
 deps:
   - name: pmm
     branch: PMM-10918-backup
+  - name: grafana
+    branch: PMM-11301-Backups-and-Restores


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-11302

This feature is a mix of Backup management and DBaaS in PMM. DBaaS supports ONLY scheduled backups at the moment and this can be enabled only when a user creates a database cluster. As for restoration, it works only as a 'Create a database cluster from backup' feature. DBaaS does not support on-demand backups and on-demand restoration yet.

## PMM side

You need to enable Backup management and Database as a Service feature in Settings->PMM Settings -> Advanced settings page

## Provisioning of the k8s cluster

Add k8s cluster on the DBaaS -> Kubernetes clusters page and wait for once it'll be provisioned. It uses an unreleased version of dbaas-operator that should be installed manually but as a first step you need to remove the version installed from dbaas-catalog

Get ready-to-use CSVs

```
kubectl get csv
NAME                                      DISPLAY                                                      VERSION   REPLACES                                  PHASE
dbaas-operator.v0.0.19                    DBaaS operator                                               0.0.19                                              Succeeded
percona-server-mongodb-operator.v1.11.0   Percona Distribution for MongoDB Operator                    1.11.0    percona-server-mongodb-operator.v1.10.0   Succeeded
percona-xtradb-cluster-operator.v1.11.0   Percona Operator for MySQL based on Percona XtraDB Cluster   1.11.0    percona-xtradb-cluster-operator.v1.10.0   Succeeded
victoriametrics-operator.v0.29.1          VictoriaMetrics Operator                                     0.29.1    victoriametrics-operator.v0.27.2          Succeeded
```

Remove dbaas-operator CSV

```
 kubectl delete csv dbaas-operator.v0.0.19
```

Check that dbaas* deployment and pods are not present in the k8s cluster

```
 kubectl get deploy
NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
percona-server-mongodb-operator   1/1     1            1           6m
percona-xtradb-cluster-operator   1/1     1            1           5m59s
vm-operator-vm-operator           1/1     1            1           6m24s
```
and the same for pods
```
kubectl get po
NAME                                               READY   STATUS    RESTARTS   AGE
percona-server-mongodb-operator-56b8687cb9-knddd   1/1     Running   0          6m34s
percona-xtradb-cluster-operator-8d5646575-qcxc7    1/1     Running   0          6m33s
vm-operator-vm-operator-7cc597c566-hng7f           1/1     Running   0          6m58s
```

## Installing and running dbaas-operator

```
git clone https://github.com/percona/dbaas-operator
cd dbaas-operator
git checkout PMM-11302-restores
make install run 
```
This will add new CRDs into the cluster and it has restores functionality while the current released version has only a backups part

## Testing backups 

You need to add a backup storage location. At the moment only s3 is supported. Open Backups-> Storage Locations -> Add storage location and fill it with your s3 bucket. For the endpoint, you can use https://s3.$REGION.amazonaws.com

Create a database cluster with the filled information for scheduled backups expected scenarios here

1. The information present in the CR of created database cluster under spec.backup field storage 
2. The backup is triggered according to the schedule you set
3. kubectl get pxc-backup or kubectl get psmdb-backup shows the status of the job. The job name has the cron-** name
4. Backup artifact is uploaded to s3 storage and you able to see it on the database cluster creation page under the restore section

## Testing restores 

1. Once you selected a location, backup artifact and the secret that contains all required secrets on the UI the creation of the cluster should be successful
2. CR file of the created cluster contains storage information under `spec.backup` field
3. kubectl get dbc-restore shows $clustername-restore job
4. kubectl get pxc-restore or kubectl get psmdb-restore shows a job with the same name as kubectl get dbc-restore
5. Once the restoration job is completed kubectl get dbc-restore and getting the object of the underlying operator shows the same statuses
6. Data is restored and present in the database cluster

## Expose database clusters on minikube

You can use MySQL client or MongoDB clients to connect to a database cluster running in minikube with minikube tunnel

run `minikube tunnel` in a separate terminal tab

edit the CR of a database cluster you want to expose and add `exposeType: LoadBalancer` for `spec.loadBalancer.exposeType` field 

Connect to the cluster and insert some data

## Test datasets 

I used [this](https://www.mysqltutorial.org/wp-content/uploads/2018/03/mysqlsampledatabase.zip) dataset to test MySQL clusters

Loading it to the cluster 

```
wget https://www.mysqltutorial.org/wp-content/uploads/2018/03/mysqlsampledatabase.zip
unzip mysqlsampledatabase.zip
mysql -h 127.0.0.1 -p -uroot < mysqlsampledatabase.sql
```

Mongo. I used this [dataset](https://github.com/neelabalan/mongodb-sample-dataset)
```
./script.sh sample 27001 userAdmin $password
```

If the aforementioned example does not work for you try to load any of small datasets https://github.com/ozlerhakan/mongodb-json-files or run tests against clean MongoDB instances 