### PR TITLE
PMM-10687 [FB] DBaaS DB clusters with unreleased PMM versions

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,7 @@
+deps:
+  # COMMON
+  - name: pmm
+    branch: PMM-10687_unreleased_pmm_version
+    path: sources/pmm/src/github.com/percona/pmm
+    url: https://github.com/percona/pmm
+    component: common


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10687
[Reopened] DBaaS: DB cluster creation fails with unreleased version of pmm-server

