### PR TITLE
PMM-11717: backward compatibility with older pmm-client

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-11717-fix-backward-compatibility


### PR DESCRIPTION
[PMM-11717](https://jira.percona.com/browse/PMM-11717)

Related PRs:
- https://github.com/percona/pmm/pull/1860
