### PR TITLE
PMM-11727: make promscrape.maxScrapeSize 64MiB by default, allow override via ENV

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-11727-too-large-responses


### PR DESCRIPTION
[PMM-11727](https://jira.percona.com/browse/PMM-11727)

Related PRs:
 - https://github.com/percona/pmm/pull/1862
