### PR TITLE
PMM-9541 Fix database discover when using socket

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: postgres_exporter
+    branch: PMM-9541-fix-socket-connection


### PR DESCRIPTION
When discovering databases and using local socket connection add trailing "/" to the database name to omit using it as a host for the connection.

https://jira.percona.com/browse/PMM-9541

- https://github.com/percona/postgres_exporter/pull/118