### PR TITLE
PMM-11957 Remove Vitess parser from our codebase.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+    - name: pmm
+      branch: PMM-11957-vitess


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-11957

- [x] Links to relevant pull requests
https://github.com/percona/pmm/pull/2070