### PR TITLE
PMM-12118 Update clickhouse plugin

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: grafana-dashboards
+    branch: PMM-12118-update-clickhouse-plugin


### PR DESCRIPTION
Update clickhouse plugin to the version v2.5.3.

https://jira.percona.com/browse/PMM-12118

- https://github.com/percona/grafana-dashboards/pull/1502
