### PR TITLE
PMM-12118 Add official clickhouse plugin

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: grafana-dashboards
+    branch: PMM-12118-add-official-clickhouse-plugin

--- a/ci.yml
+++ b/ci.yml
@@ -1,3 +1,5 @@
 deps:
   - name: grafana-dashboards
     branch: PMM-12118-add-official-clickhouse-plugin
+  - name: pmm
+    branch: PMM-12118-skip-plugin-binaries-stripping


### PR DESCRIPTION
Add official clickhouse plugin to Grafana installation.

https://jira.percona.com/browse/PMM-12118

- https://github.com/percona/grafana-dashboards/pull/1503
