### PR TITLE
Revert PMM-12175 fix supervisorctl path for EL7.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: revert-2254-PMM-12175-fix-postgres-supervisorctl


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-0

- [ ] Links to relevant pull requests
