### PR TITLE
PMM-12880 Proper skip for MySQL TLS certs.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,1 +1,3 @@
-
+deps:
+    - name: pmm
+      branch: PMM-12880-mysql-tls-skip


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-12880

- [x] Links to relevant pull requests
https://github.com/percona/pmm/pull/2909