### PR TITLE
PMM-7 Remove .git suffix from repo URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,15 +7,15 @@
 # PMM Client
 [submodule "node_exporter"]
 	path = sources/node_exporter/src/github.com/prometheus/node_exporter
-	url = https://github.com/percona/node_exporter.git
+	url = https://github.com/percona/node_exporter
 	branch = v3
 [submodule "mysqld_exporter"]
 	path = sources/mysqld_exporter/src/github.com/percona/mysqld_exporter
-	url = https://github.com/percona/mysqld_exporter.git
+	url = https://github.com/percona/mysqld_exporter
 	branch = main
 [submodule "mongodb_exporter"]
 	path = sources/mongodb_exporter/src/github.com/percona/mongodb_exporter
-	url = https://github.com/percona/mongodb_exporter.git
+	url = https://github.com/percona/mongodb_exporter
 	branch = main
 [submodule "postgres_exporter"]
 	path = sources/postgres_exporter/src/github.com/percona/postgres_exporter
@@ -23,7 +23,7 @@
 	branch = main
 [submodule "proxysql_exporter"]
 	path = sources/proxysql_exporter/src/github.com/percona/proxysql_exporter
-	url = https://github.com/percona/proxysql_exporter.git
+	url = https://github.com/percona/proxysql_exporter
 	branch = main
 [submodule "rds_exporter"]
 	path = sources/rds_exporter/src/github.com/percona/rds_exporter
@@ -35,7 +35,7 @@
 	branch = main
 [submodule "percona-toolkit"]
 	path = sources/percona-toolkit/src/github.com/percona/percona-toolkit
-	url = https://github.com/percona/percona-toolkit.git
+	url = https://github.com/percona/percona-toolkit
 	branch = release-v3.5.2
 
 # PMM Server


### PR DESCRIPTION
**Problem**

I was working on [a feature](https://github.com/Percona-Lab/pmm-submodules/pull/3833/files#r1930650535) for https://github.com/percona/mysqld_exporter. This repository name is saved in the `.gitmodules` file with a `.git` suffix. It turns out, our python script fails because it is unable to work with the `.git` extension. Specifically, the following [call](https://github.com/Percona-Lab/pmm-submodules/pull/3833/files#diff-a46b62f74aa95ff66b8bde3db18f452707aea2894b9a7ff5d5c3ca5d436906efR237) fails: `github_api.get_repo(repo_path)`.

**Solution**

Remove `.git` suffixes from the repository URLs in `.gitmodules`. This will also bring consistency to repository URLs.