### PR TITLE
PMM-7 Add 'git pull' step to the 'trigger' target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ deps:                       ## Get deps from repos.
 	python3 ci.py
 
 trigger:                    ## Make an empty commit to trigger the build.
+	git pull
 	git commit -m 'chore: trigger FB' --allow-empty
 	git push
 


### PR DESCRIPTION
Ensures the local repository is up-to-date before creating an empty commit to trigger the build. This prevents potential issues caused by outdated local branches during the process.

https://jira.percona.com/browse/PMM-0

- [ ] Links to relevant pull requests
