### PR TITLE
PMM-14294 Use ubi10 as a base image for pmm-client container image.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-14294-pmm-client-ubi10


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-14294