### PR TITLE
PMM-7 Rename Grafana branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,7 +46,7 @@
 [submodule "grafana"]
 	path = sources/grafana/src/github.com/grafana/grafana
 	url = https://github.com/percona/grafana
-	branch = v3
+	branch = main
 [submodule "pmm-dump"]
 	path = sources/pmm-dump
 	url = https://github.com/percona/pmm-dump


### PR DESCRIPTION
This pull request makes a minor update to the `.gitmodules` file, changing the tracked branch for the `grafana` submodule from `v3` to `main`. This ensures the submodule will now follow the latest changes from the main development branch.
