### PR TITLE
PMM-14831 Add fsync lock state metrics from currentOp

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: mongodb_exporter
+    branch: abhi021:feature/currentop-fsync-lock-metrics


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-14831

- https://github.com/percona/mongodb_exporter/pull/1221
