### PR TITLE
PMM-14829 Update percona-toolkit submodule branch to release-v3.7.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 [submodule "percona-toolkit"]
 	path = sources/percona-toolkit/src/github.com/percona/percona-toolkit
 	url = https://github.com/percona/percona-toolkit
-	branch = release-v3.7.2
+	branch = release-3.7.2
 
 # PMM Server
 [submodule "grafana-dashboards"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 [submodule "percona-toolkit"]
 	path = sources/percona-toolkit/src/github.com/percona/percona-toolkit
 	url = https://github.com/percona/percona-toolkit
-	branch = release-v3.7.1
+	branch = release-v3.7.2
 
 # PMM Server
 [submodule "grafana-dashboards"]


### PR DESCRIPTION
[PMM-14829](https://perconadev.atlassian.net/browse/PMM-14829)

Updated the branch for the percona-toolkit submodule from release-v3.7.1 to release-v3.7.2.

- https://github.com/percona/percona-toolkit/pull/1084


[PMM-14829]: https://perconadev.atlassian.net/browse/PMM-14829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ