### PR TITLE
fix(trivy): pin trivy-action to SHA instead of @master

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -33,7 +33,7 @@ jobs:
           echo "REPORT=$(echo ${{ matrix.image }} | cut -d'/' -f2 | tr ':' '-')" >> $GITHUB_ENV
 
       - name: Run trivy scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ matrix.image }}
           format: 'table'


### PR DESCRIPTION
## Summary

Pin `aquasecurity/trivy-action` from mutable `@master` to the commit SHA of v0.35.0.

```diff
- uses: aquasecurity/trivy-action@master
+ uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
```

## Context

Supply chain response to GHSA-69fq-xp46-6x23 (Trivy compromise, March 2026). The `@master` branch was compromised on March 19; 75 of 76 version tags were force-pushed with malicious commits. SHA pinning prevents future tag/branch hijacking.

This workflow dodged the compromise by scheduling luck (weekly Monday cron at 07:00 UTC fell outside the ~12h window), not by design.