### PR TITLE
PMM-15006 Upgrade VictoriaMetrics to version 1.140.0 and fix Go toolchain

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+- name: pmm
+  branch: PMM-15006-use-same-go-toolchain-for-vm
+  url: https://github.com/percona/pmm


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-15006

- https://github.com/percona/pmm/pull/5280
