### PR TITLE
Increase fetch depth to 10 for branch switching so that Launchable ca…

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -274,7 +274,7 @@ def switch_branch(path, branch):
         if branch in branches:
             print(f'Switch to branch: {branch} (from {cur_branch})')
             check_call(f'git remote set-branches origin {branch}'.split(), cwd=path)
-            check_call(f'git fetch --depth 1 origin {branch}'.split(), cwd=path)
+            check_call(f'git fetch --depth 10 origin {branch}'.split(), cwd=path)
             check_call(f'git checkout {branch}'.split(), cwd=path)
         else:
             logging.error(f'Can\' find branch: {branch} in {path}')


### PR DESCRIPTION
…n collect commits correctly

I'm a software engineer at Launchable and am currently supporting Percona PMMDB team. 

Vasyl, QA engineer at the PMMDB, mentioned that Launchable was not able to pick up right tests related to the file changes.

After investigating, I found the problem occurred because Launchable was failing to collect commits in the repository. For example:
* In build #[5044896](https://app.launchableinc.com/organizations/percona/workspaces/workshop/data/builds/5044896), a shallow clone was used in ./sources/mysqld_exporter/src/github.com/percona/mysqld_exporter.
* In build #[5053417](https://app.launchableinc.com/organizations/percona/workspaces/workshop/data/builds/5053417), a shallow clone was used in ./sources/pmm/src/github.com/percona/pmm.
* In build #[5044824](https://app.launchableinc.com/organizations/percona/workspaces/workshop/data/builds/5044824), a shallow clone was used in ./sources/grafana/src/github.com/grafana/grafana and ./sources/pmm-dump.


When a shallow clone is used, we cannot collect commits and file changes accurately, which is likely why his expected test cases were not prioritized correctly. Given these examples, it seems something went wrong in the checked-out repositories.
This problem should be resolved by increasing the depth of repositories.


This PR addresses it. 

