### PR TITLE
PMM-15044 bump VictoriaMetrics to 1.143.0, Nomad to 2.0.1

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+- name: pmm
+  branch: PMM-15044-bump-victoriametrics-to-1.143.0
+  url: https://github.com/percona/pmm


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-15044

- https://github.com/percona/pmm/pull/5374
