### PR TITLE
revert-5435-PMM-15039-disable-telemetry-except-for-ga-rc-builds

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: revert-5435-PMM-15039-disable-telemetry-except-for-ga-rc-builds
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-5435

- https://github.com/percona/pmm/pull/5482
