### PR TITLE
PMM-14154 Migrate from v3 to main in the monorepo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "pmm"]
 	path = sources/pmm/src/github.com/percona/pmm
 	url = https://github.com/percona/pmm
-	branch = v3
+	branch = main
 
 # PMM Client
 [submodule "node_exporter"]


### PR DESCRIPTION
Updated the branch for the 'pmm' submodule from 'v3' to 'main'.

https://jira.percona.com/browse/PMM-14154

- https://github.com/percona/pmm/pull/5498
