### PR TITLE
PMM-15032 Disable dnf-makecache.timer in worker AMI to prevent dnf lock contention.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-15032-disable-makecache-timer


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-15032