### PR TITLE
PMM-15174-fix-router-cluster-var (FB)

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: PMM-15174-fix-router-cluster-var
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
## Feature build for PMM-15174
Fix wrong `cluster` variable in the MongoDB Router Summary dashboard.

- [ ] percona/pmm: https://github.com/percona/pmm/pull/5608
