### PR TITLE
PMM-7 Restore SELinux permissive mode in AMI build to fix pmm-server SELinux Enforcing crash on fresh volumes.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-7-fix-ami-build


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-7