### PR TITLE
PMM-15241: Restore update popup snooze using UI-owned duration after settings field removal

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15241-fix-update-popup-snooze
+    url: https://github.com/percona/pmm


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-15241

- [ ] https://github.com/percona/pmm/pull/5694

### QA: localStorage snooze override

For QA only. Default snooze is still **7 days**. To test expiry without waiting:

```js
localStorage.setItem('pmm-ui.dev.updateSnoozeDurationMs', '10000'); // 10s
// Remind me later → wait >10s → refresh → popup should show again
localStorage.removeItem('pmm-ui.dev.updateSnoozeDurationMs'); // reset