### PR TITLE
Feature build for PMM-15285-remove-redundant-go-maintail

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: PMM-15285-remove-redundant-go-maintail
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the changes in https://github.com/percona/pmm/pull/5723.

Related PRs:
- [ ] https://github.com/percona/pmm/pull/5723