### PR TITLE
PMM-14979 share-enc-key-between-nodes

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: PMM-14979-share-enc-key-between-nodes
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the changes in https://github.com/percona/pmm/pull/5735.

Related PRs:
- [ ] https://github.com/percona/pmm/pull/5735
- [ ] https://github.com/percona/percona-helm-charts/pull/921

Note: percona/pmm#5735 is based on percona/pmm#5587 (`PMM-15188`), so this build includes that PR's changes as well.