### PR TITLE
PMM-15308 Feature build

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-15308-trim-dashboard-titles


### PR DESCRIPTION
## Feature build for PMM-15308

Trims leading/trailing whitespace from 39 dashboard titles and adds a `trim_titles` guard to `cleanup-dash.py` so CI catches regressions.

- [ ] percona/pmm: https://github.com/percona/pmm/pull/5767

Ticket: https://perconadev.atlassian.net/browse/PMM-15308