### PR TITLE
PMM-15184 Feature build for Disk Details stacking fix

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15184-fix-disk-details-stacking-legend
+    url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for **PMM-15184** — https://perconadev.atlassian.net/browse/PMM-15184

Builds PMM Server and Client from the `percona/pmm` branch that fixes the Disk Details mountpoint panel.

## Component PRs

- [ ] percona/pmm — https://github.com/percona/pmm/pull/5823

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15184-fix-disk-details-stacking-legend
    url: https://github.com/percona/pmm
```

Single repo — the change is one file, `dashboards/dashboards/OS/Disk_Details.json` (panel `1023`). No grafana-fork, exporter or pmm-qa branch is involved.

## What to check in the built image

Open **Disk Details** for a node with a large disk, expand the **Disk Space** row, and look at the **Mountpoint $mountpoint** panel:

1. The `Used` + `Free` stack tops out at the device's **true capacity**, not 2× it. On `origin/main` a 47.7 TiB device renders a ~96 TiB stack; verified locally as 58.4 GiB instead of ~117 GiB on a 58.37 GiB device.
2. `Total` renders as an **unfilled dark-red reference line** lying along the top of the stack — not as a filled band stacked above it.
3. The legend shows **Mean / Max / Min / Last** columns per series, instead of only `Last`.

Nothing else in the dashboard should change: all 21 panel ids, the `node-disk` uid, and every query and unit are untouched, so existing deep links must keep working.

---

Draft, per the FB convention — to be closed once the component PR merges.
