### PR TITLE
PMM-15160 Feature build for QAN sparkline fix

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15160-fix-qan-sparklines-divide-by-zero
+    url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for **PMM-15160** — https://perconadev.atlassian.net/browse/PMM-15160

Builds PMM Server and Client from the `percona/pmm` branch that stops `qan-api2` panicking with an integer divide by zero when a QAN report's time range collapses into a single minute.

## Component PRs

- [ ] percona/pmm — https://github.com/percona/pmm/pull/5824

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15160-fix-qan-sparklines-divide-by-zero
    url: https://github.com/percona/pmm
```

Single repo — the change is confined to `qan-api2/`. No grafana-fork, exporter or pmm-qa branch is involved.

## What to check in the built image

Server-side only; no client involvement. Against a PMM with some QAN data:

1. **The panic is gone.** Open QAN and drag the smallest possible time selection (start and end inside the same minute), or call the API directly:
   ```
   POST /v1/qan/metrics:getReport
   {"period_start_from":"<T>:44:10Z","period_start_to":"<T>:44:50Z","group_by":"queryid","columns":["load"],"order_by":"-load","limit":10}
   ```
   Expect **200** with a one-point sparkline (`time_frame: 60`). Before this change it was **500** `{"code":13,"message":"Internal server error."}` plus a stack in `/srv/logs/qan-api2.log`:
   ```
   docker exec -it pmm-server grep -c "divide by zero" /srv/logs/qan-api2.log   # expect 0
   ```
2. **The same on the second panic path**, which the ticket does not mention — `POST /v1/qan:getMetrics` with the same range.
3. **No non-finite numbers in the response.** With `period_start_from == period_start_to`, `getReport`, `getMetrics` and `getFilters` must contain no `"Infinity"` or `"NaN"` in any float field. `getFilters` previously returned 24 of each; the generated API clients cannot decode either.
4. **Reversed ranges are rejected consistently.** `from > to` on `getReport`, `getMetrics` (including `totals: true`) and `getFilters` must return **400** `InvalidArgument`, not 500 and not a fabricated data point.
5. **Nothing else moved.** Normal ranges must be unchanged — verified locally as byte-identical responses across 12 requests (3 RPCs × 1h / 1d / 30d / exactly-2h) between the base and fixed binaries.

---

Draft, per the FB convention — to be closed once the component PR merges.
