### PR TITLE
PMM-15363 Feature build

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15363-fix-zero-load-average-mapping
+    url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the PMM-15363 dashboard fix, so the **Nodes Overview** panel can be checked on a real server.

## Component PRs

- [ ] percona/pmm — https://github.com/percona/pmm/pull/5837

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15363-fix-zero-load-average-mapping
    url: https://github.com/percona/pmm
```

## What to look at once the images are up

On *MongoDB Sharded Cluster Summary* or *MongoDB ReplSet Summary* → **Nodes Overview**:

| case | expected |
|---|---|
| idle node, Load Average `0` | `0.00` — not "No Data" |
| Memory Available `0%` | `0.00%` |
| filesystem 100 % full | Min Space Available `0.00%` |
| metric genuinely absent | `-` |
| k8s pod with no memory limit | RAM / Virtual Memory still "No Data", never `0.00 B` |

Draft, and expected to be closed rather than merged once the component PR lands.