### PR TITLE
PMM-15362 Disable default-on node_exporter collectors

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15362-disable-default-node-collectors
+    url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature Build for **PMM-15362** — `--disable-collectors` had no effect for node_exporter collectors that node_exporter enables by default.

Builds PMM Server and Client from the fix branch so the change can be tested as an image. The fix is server-side (`pmm-managed` generates the exporter command line) plus a one-line `pmm-admin` change, so only the `pmm` monorepo is pinned.

## Component PRs

- [ ] percona/pmm — https://github.com/percona/pmm/pull/5839

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15362-disable-default-node-collectors
    url: https://github.com/percona/pmm
```

## What to check on the built image

1. Register a client, then: `pmm-admin inventory change agent node-exporter <agent_id> --disable-collectors=diskstats`
2. The exporter command line should now carry `--no-collector.diskstats` (before the fix, the `--collector.diskstats` enable flag was merely removed, which is a no-op for a default-on collector).
3. `curl -s http://pmm:<agent_id>@127.0.0.1:<port>/metrics | grep -c '^node_disk_'` → `0` (was 324).
4. `--disable-collectors=cpu,cpu` must **not** stop node_exporter from starting — a repeated flag is rejected by its flag parser, so the server de-duplicates.
5. `--disable-collectors="cpu, meminfo"` (with a space) must disable both — the `change agent` path now trims, as `add` already did.
6. Control: `--disable-collectors=processes` (a non-default collector) must keep working and must **not** gain a `--no-collector.processes` flag.

Full evidence, including a live before/after on an isolated PMM 3.10.0 server, is in the component PR's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
