### PR TITLE
PMM-15389 Assume IAM role for RDS monitoring (full stack)

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-0000-rds-iam-role-arn
+    url: https://github.com/fergalhk/pmm

--- a/ci.yml
+++ b/ci.yml
@@ -1,4 +1,5 @@
 deps:
   - name: pmm
-    branch: PMM-0000-rds-iam-role-arn
-    url: https://github.com/fergalhk/pmm
+    branch: PMM-15389-rds-assume-iam-role
+  - name: grafana
+    branch: PMM-15389-rds-role-arn-ui


### PR DESCRIPTION
Feature build for assumed-IAM-role RDS monitoring: PMM assumes an AWS IAM role instead of using static access keys to monitor RDS.

Full stack, pinned on branches we own (the contributor PR percona/pmm#5804 is left untouched):

**pmm: `PMM-15389-rds-assume-iam-role`**
- Adopts percona/pmm#5804 (assume IAM roles for RDS), authored by the original contributor.
- Fixes the four review defects on top: pmm-agent 3.4.0 version gate, bounded + validated STS role assumption, explicit clearing of a role ARN (no silent revert to ambient credentials), and role-partition check against PMM settings.
- Wires `instance_id` through the inventory node API and `pmm-admin`, so the rds_exporter actually has a DB instance to scrape. This delivery-surface gap predates #5804 and blocks it.

**grafana: `PMM-15389-rds-role-arn-ui`**
- Adds the AWS IAM role ARN field to the Add Instance / Discovery credentials form, with ARN-format and keys-vs-role exclusivity validation.

Docs companion: percona/pmm#5941.

Draft: built for end-to-end testing on AWS, not for merge.
