### PR TITLE
PMM-15398 Build dashboards memory fix

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-15398-memory-used-shmem


### PR DESCRIPTION
Feature build for **PMM-15398** — node `Used` memory now counts PostgreSQL `shared_buffers`.

`Used` was `MemTotal - (MemFree + Buffers + Cached)`, and `/proc/meminfo:Cached` includes `Shmem`, so `shared_buffers` was subtracted out of `Used` and re-drawn as `Cache`. This build carries the corrected expressions so QA can check the OS dashboards against `free` on a real PostgreSQL node.

## Component PRs

- [ ] percona/pmm — https://github.com/percona/pmm/pull/5855

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15398-memory-used-shmem
```

## What to look at

Open **OS → Node Summary → Memory Utilization** for a PostgreSQL node with a large `shared_buffers` and compare `Used` against `free -m` on that host. Also check **Memory Details → Memory Usage**, **Nodes Compare**, and **Nodes Overview → Top 5 Used Memory**.

Two things worth checking explicitly:

- The stacked panel must still sum to `MemTotal` — `Used + Free + Buffers + Cache`.
- An **RDS** node must be unchanged, not blank. `rds_exporter` does not export `SReclaimable` or `Shmem`, and the expressions carry a zero-fallback for exactly that case.

`Used` reads higher than before on every node — that is the fix, not a regression.

## Ticket

- https://perconadev.atlassian.net/browse/PMM-15398
