### PR TITLE
Feature build for PMM-14807-use-connection-pooling-for-performance

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: mongodb_exporter
+      branch: PMM-14807-use-connection-pooling-for-performance
+      url: https://github.com/percona/mongodb_exporter


### PR DESCRIPTION
Feature build for the changes in https://github.com/percona/mongodb_exporter/pull/1348.

Builds `mongodb_exporter` (not `pmm`) from the branch under test: the change lives in the `mongodb_exporter` submodule.

Related PRs:
- [ ] https://github.com/percona/mongodb_exporter/pull/1348