### PR TITLE
Feature build for PMM-15404-fix-pg-migration-crashloop

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: PMM-15404-fix-pg-migration-crashloop
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the changes in https://github.com/percona/pmm/pull/5867.

Pinned component: `pmm` @ `PMM-15404-fix-pg-migration-crashloop` (https://github.com/percona/pmm)

Related PRs:
- [ ] https://github.com/percona/pmm/pull/5867
