### PR TITLE
Feature build for PMM-15304-fix-node-type-detection

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: PMM-15304-fix-node-type-detection
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the changes in https://github.com/percona/pmm/pull/5870.

Pinned component: `pmm` @ `PMM-15304-fix-node-type-detection` (https://github.com/percona/pmm)

Related PRs:
- [ ] https://github.com/percona/pmm/pull/5870
