### PR TITLE
PMM-14678 Rework vmagent remote-write routing

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,3 @@
+deps:
+  - name: pmm
+    branch: PMM-14678-vmagent-write-paths


### PR DESCRIPTION
Feature build for the PMM Server change that routes HA client metric writes through HAProxy to vmauth.

Component PRs:

- [ ] https://github.com/percona/pmm/pull/5887

Related chart change (not part of this build; QA deploys it from its branch): https://github.com/percona/percona-helm-charts/pull/952

Ticket: https://perconadev.atlassian.net/browse/PMM-14678

Supersedes #4451, which built the previous branch for this ticket.