### PR TITLE
PMM-15475 Feature build

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15475-telemetry-kubernetes-signal
+    url: https://github.com/percona/pmm

--- a/ci.yml
+++ b/ci.yml
@@ -1,4 +1,3 @@
 deps:
   - name: pmm
     branch: PMM-15475-telemetry-kubernetes-signal
-    url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the PMM-15475 telemetry Kubernetes datapoints, so QA has a server image to verify against.

## Component PRs

- [ ] https://github.com/percona/pmm/pull/5905

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15475-telemetry-kubernetes-signal
    url: https://github.com/percona/pmm
```

Single repo — only `percona/pmm` is pinned; every other dependency stays at its default.

## What QA needs to know

The change adds two telemetry presence flags, `pmm_server_installed_with_helm` and `pmm_server_in_kubernetes`, which distinguish a PMM Server on Kubernetes from one under Docker. Test instructions are on PMM-15475.

This is a feature build, so `pmm-managed` will **build and log** the telemetry report but never send it — sending is skipped for non-release versions. QA verifies from `/srv/logs/pmm-managed.log` with `PMM_DEBUG=1`, not from the Percona portal.

Draft on purpose: to be closed, not merged, once the component PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
