### PR TITLE
PMM-15379 Feature build

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+  - name: pmm
+    branch: PMM-15379-lbac-datasource-proxy-prefix
+    url: https://github.com/percona/pmm


### PR DESCRIPTION
[PMM-15379](https://perconadev.atlassian.net/browse/PMM-15379)

## Component PRs

- [ ] https://github.com/percona/pmm/pull/5923

## ci.yml

```yaml
deps:
  - name: pmm
    branch: PMM-15379-lbac-datasource-proxy-prefix
    url: https://github.com/percona/pmm
```

Single repo — only `percona/pmm` is pinned; every other dependency stays at its default. Rebuilt components are `pmm-managed` and `vmproxy`.

## What QA needs to know

Two changes on the Grafana data source surface:

1. **Label-based access control now applies to every data source proxy URL form.** Previously only `/graph/api/datasources/proxy/1/api/v1/...` was filtered, so a user restricted by an access-control role could read unfiltered metrics through the UID form or through a data source whose numeric id was not 1.
2. **vmproxy now forwards only the VictoriaMetrics query endpoints.** Anything else — snapshots, `/metrics`, `/flags`, `/debug/pprof/*`, `/api/v1/status/config`, `/api/v1/targets`, the `/api/v1/admin/*` surface — returns `403` with a warn line in `/srv/logs/vmproxy.log` naming the path.

### The main regression risk is dashboards

Change 2 restricts what can pass through the Metrics data source, so the thing worth testing hardest is that **normal dashboard use is unaffected**: panels render, template variables populate, Explore works, and QAN is unaffected. Any panel that breaks will leave a `Refusing request to a path outside the read-only allow-list` line in `/srv/logs/vmproxy.log` with the exact path — please attach that line if you hit one, it identifies a missing entry directly.

Verified before submitting by driving 10 dashboards plus Explore in a browser against a patched 3.10.0 server: zero non-2xx responses, all template-variable lookups fine, and the deny log empty for the whole run. That was on a server with only PMM's own PostgreSQL monitored, so dashboards for MySQL, MongoDB, ProxySQL, HAProxy and the cloud integrations are exactly what this run did not cover.

### Also worth checking

- An access-control role with a label filter must filter identically on every proxy URL form, not just `proxy/1`.
- Admin access to VictoriaMetrics through `/prometheus/*` is unchanged and must still work — it does not cross vmproxy.
- Metric ingestion is unaffected: vmagent writes via a route that bypasses vmproxy. Confirm clients still report data.


[PMM-15379]: https://perconadev.atlassian.net/browse/PMM-15379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ