### PR TITLE
Feature build for PMM-15322-valkey-exporter-tls-flags

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,4 @@
+deps:
+    - name: pmm
+      branch: PMM-15322-valkey-exporter-tls-flags
+      url: https://github.com/percona/pmm


### PR DESCRIPTION
Feature build for the changes in https://github.com/percona/pmm/pull/5854.

Pinned component: `pmm` @ `PMM-15322-valkey-exporter-tls-flags` (https://github.com/percona/pmm)

Related PRs:
- [ ] https://github.com/percona/pmm/pull/5854
